### PR TITLE
Fix #10

### DIFF
--- a/Assets/Adrenak.Unex/Runtime/Extensions/UnityAPIExtensions.cs
+++ b/Assets/Adrenak.Unex/Runtime/Extensions/UnityAPIExtensions.cs
@@ -98,6 +98,7 @@ namespace Adrenak.Unex {
 			return tex;
 		}
 
+#if !UNEX_DISABLE_WEBCAM
 		public static Texture2D GetFrame(this WebCamTexture tex) {
 			if (!tex.isPlaying) return null;
 			var result = new Texture2D(tex.width, tex.height);
@@ -105,6 +106,7 @@ namespace Adrenak.Unex {
 			result.Apply();
 			return result;
 		}
+#endif
 
 		public static Object LoadObject(this AssetBundle bundle, string name, bool unload) {
 			var temp = bundle.LoadObjects(new string[] { name }, unload);


### PR DESCRIPTION
To disable methods that require a webcam, define `UNEX_DISABLE_WEBCAM`. A particular platform I'm working with doesn't provide the `WebCamTexture` API, although I'm bound by an NDA that prevents me from saying which one.